### PR TITLE
Add snapshot date to Results.yaml

### DIFF
--- a/R/BindResults.R
+++ b/R/BindResults.R
@@ -40,8 +40,11 @@ BindResults <- function(
     ) %>%
     purrr::list_rbind()
 
-  if (!is.null(dSnapshotDate)) {
-    dfResults$SnapshotDate <- dSnapshotDate
+  # If NULL or the placeholder string was passed in, use Sys.Date()
+  if (is.null(dSnapshotDate) || (is.character(dSnapshotDate) && dSnapshotDate == "dSnapshotDate")) {
+    dfResults$SnapshotDate <- Sys.Date()
+  } else {
+    dfResults$SnapshotDate <- as.Date(dSnapshotDate)
   }
 
   if (!is.null(strStudyID)) {

--- a/inst/workflow/3_reporting/Results.yaml
+++ b/inst/workflow/3_reporting/Results.yaml
@@ -25,4 +25,5 @@ steps:
       lAnalysis: lAnalyzed
       strName: "Analysis_Summary"
       strStudyID: strStudyID
+      dSnapshotDate: dSnapshotDate
 


### PR DESCRIPTION
closes #24 

While testing out the calculate changes, I realized the snapshot date columns were the same despite using diff snapshots. This should allow a fed in param or default to sys date if null or nothing replaces the character