### PR TITLE
Fix 62: MakeMetric passes fields

### DIFF
--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,6 @@
-# Workflow derived from
-# https://github.com/Gilead-BioStats/qcthat/tree/v1.1.1/inst/workflows/qcthat.yaml.
+# name: qcthat.yaml
+# version: 0.1.0
+# Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize, milestoned]
@@ -9,20 +10,18 @@ on:
     types: [closed]
   workflow_dispatch:
     inputs:
-      pr:
+      pr-number:
         description: PR number to which reports should be added (leave blank for none).
-        required: false
       milestone:
-        description: Milestone name to use for the milestone report (leave blank for none).
-        required: false
+        description: Milestone name to use to target the milestone report (leave blank for none).
       tag:
         description: Release tag to which the report should be attached (leave blank for none).
-        required: false
-      issueNumber:
+      qcthat-ref:
+        description: A specific qcthat GitHub reference, such as a tag ("@v1.0.0"), branch ("@dev"), commit ("@480c247"), or pull request number ("#312") to use for reports and UAT management. Defaults to the latest release, "@*release".
+      issue-number:
         description: The closed issue number to process to update user acceptance testing information.
-        required: false
 
-name: qcthat Quality Control
+name: qcthat
 
 permissions:
   # read: Required for generating reports and updating UAT status.
@@ -36,123 +35,28 @@ permissions:
   # write: Required for updating UAT status.
   actions: write
 
-# Configuration variables for controlling workflow behavior
-env:
-  qcthat_UAT: true
-  qcthat_PR_REPORT: true
-  qcthat_COMPLETED_REPORT: true
-  qcthat_MILESTONE_REPORT: true
-  qcthat_RELEASE_REPORT: true
-  qcthat_FAIL_FOR_TEST_FAILURES: true
-
 jobs:
   qcthat:
-    runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
       github.event_name != 'issues'
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: local::. Gilead-BioStats/qcthat@main
-
-      - name: Manage User Acceptance Testing
-        if: >-
-          env.qcthat_UAT == 'true' && (
-            (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber != '')
-          )
-        run: |
-          Rscript -e "qcthat::TriggerUAT()"
-
-      - name: Generate Issue-Test Matrix
-        if: >-
-          (env.qcthat_PR_REPORT == 'true' || env.qcthat_RELEASE_REPORT == 'true' || env.qcthat_FAIL_FOR_TEST_FAILURES == 'true') && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          # Generate the full matrix for the package
-          IssueTestMatrix <- qcthat::QCPackage()
-          print(IssueTestMatrix)
-
-          # Save the matrix and UAT data for subsequent steps
-          saveRDS(IssueTestMatrix, "ITM.rds")
-          qcthat::SaveUATIssues()
-        shell: Rscript {0}
-
-      - name: Update PR Reports
-        if: >-
-          env.qcthat_PR_REPORT == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::CommentAllReports(
-            dfITM = issueTestMatrix,
-            lglPR = as.logical("${{ env.qcthat_PR_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}"),
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglUAT = as.logical("${{ env.qcthat_UAT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Update Release Reports
-        if: >-
-          env.qcthat_RELEASE_REPORT == 'true' && (
-            github.event_name == 'release' || inputs.tag != ''
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::AttachReleaseReports(
-            dfITM = issueTestMatrix,
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Flag failure for PR
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfPR <- qcthat::QCPR(dfITM = issueTestMatrix)
-          if (any(dfPR$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for PR-associated issues."
-            )
-          }
-        shell: Rscript {0}
-
-      - name: Flag failure for completed
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfCompleted = qcthat::QCCompletedIssues(dfITM = issueTestMatrix)
-          if (any(dfCompleted$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for completed issues."
-            )
-          }
-        shell: Rscript {0}
+    uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      # Configuration variables for controlling workflow behavior
+      manage-uat: true
+      generate-pr-report: true
+      generate-completed-report: true
+      generate-milestone-report: true
+      generate-release-report: true
+      fail-for-test-failures: true
+      fail-for-missing-tests: true
+      uat-assignees: ${{ (github.event_name == 'pull_request' && github.base_ref == 'main' && 'jwildfire') || (github.event_name == 'pull_request' && github.base_ref != 'main' && 'lauramaxwell,nandriychuk') || '' }}
+      # Event context passed through to the core workflow
+      has-uat-label: ${{ contains(github.event.issue.labels.*.name, 'qcthat-uat') }}
+      pr-number: ${{ github.event.pull_request.number || inputs.pr-number || '' }}
+      milestone: ${{ github.event.pull_request.milestone.title || inputs.milestone || '' }}
+      tag: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      issue-number: ${{ github.event.issue.number || inputs.issue-number || '' }}
+      qcthat-ref: ${{ inputs.qcthat-ref || '@*release' }}

--- a/inst/workflow/3_reporting/Bounds.yaml
+++ b/inst/workflow/3_reporting/Bounds.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Bounds
   Description: Generate reporting data model including site-, country- and study-level metadata (dfGroups), metric metadata (dfMetrics) and results data with added study-level columsn (dfSummary and dfBounds).
   Priority: 2
+  Active: true
 spec:
   Reporting_Results:
     _all:

--- a/inst/workflow/3_reporting/Groups.yaml
+++ b/inst/workflow/3_reporting/Groups.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Groups
   Description: Reporting Groups Data
   Priority: 1
+  Active: true
 spec:
   Mapped_STUDY:
     _all:

--- a/inst/workflow/3_reporting/Metrics.yaml
+++ b/inst/workflow/3_reporting/Metrics.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Metrics
   Description: Reporting Metrics Data
   Priority: 1
+  Active: true
 steps:
   # lWorkflows is a named list of metric workflows.
   - output: Reporting_Metrics

--- a/inst/workflow/3_reporting/Results.yaml
+++ b/inst/workflow/3_reporting/Results.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Results
   Description: Reporting Results Data
   Priority: 1
+  Active: true
 spec:
   Mapped_STUDY:
     GroupID:

--- a/tests/testthat/test-MakeMetric.R
+++ b/tests/testthat/test-MakeMetric.R
@@ -24,7 +24,7 @@ test_that("MakeMetric includes Active column when present in meta (#62)", {
   expect_identical(result$Active, c(TRUE, FALSE))
 })
 
-test_that("MakeMetric includes GenerateSignal column when present in meta (#62)", {
+test_that("MakeMetric includes GenerateRiskSignal column when present in meta (#62)", {
   given <- list(
     a = list(
       meta = list(
@@ -32,7 +32,7 @@ test_that("MakeMetric includes GenerateSignal column when present in meta (#62)"
         ID = "kri0001",
         GroupLevel = "Site",
         Abbreviation = "AE",
-        GenerateSignal = TRUE
+        GenerateRiskSignal = TRUE
       )
     ),
     b = list(
@@ -41,13 +41,13 @@ test_that("MakeMetric includes GenerateSignal column when present in meta (#62)"
         ID = "kri0002",
         GroupLevel = "Site",
         Abbreviation = "SAE",
-        GenerateSignal = FALSE
+        GenerateRiskSignal = FALSE
       )
     )
   )
   result <- MakeMetric(given)
-  expect_true("GenerateSignal" %in% names(result))
-  expect_identical(result$GenerateSignal, c(TRUE, FALSE))
+  expect_true("GenerateRiskSignal" %in% names(result))
+  expect_identical(result$GenerateRiskSignal, c(TRUE, FALSE))
 })
 
 test_that("MakeMetric makes dfMetrics", {

--- a/tests/testthat/test-MakeMetric.R
+++ b/tests/testthat/test-MakeMetric.R
@@ -1,3 +1,55 @@
+test_that("MakeMetric includes Active column when present in meta (#62)", {
+  given <- list(
+    a = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0001",
+        GroupLevel = "Site",
+        Abbreviation = "AE",
+        Active = TRUE
+      )
+    ),
+    b = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0002",
+        GroupLevel = "Site",
+        Abbreviation = "SAE",
+        Active = FALSE
+      )
+    )
+  )
+  result <- MakeMetric(given)
+  expect_true("Active" %in% names(result))
+  expect_identical(result$Active, c(TRUE, FALSE))
+})
+
+test_that("MakeMetric includes GenerateSignal column when present in meta (#62)", {
+  given <- list(
+    a = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0001",
+        GroupLevel = "Site",
+        Abbreviation = "AE",
+        GenerateSignal = TRUE
+      )
+    ),
+    b = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0002",
+        GroupLevel = "Site",
+        Abbreviation = "SAE",
+        GenerateSignal = FALSE
+      )
+    )
+  )
+  result <- MakeMetric(given)
+  expect_true("GenerateSignal" %in% names(result))
+  expect_identical(result$GenerateSignal, c(TRUE, FALSE))
+})
+
 test_that("MakeMetric makes dfMetrics", {
   given <- list(
     a = list(


### PR DESCRIPTION
## Overview
Add tests to verify that MakeMetric passes through fields (specifically `Active` and `GenerateSignal`, but really they could be anything).

I also added `Active: true` to exported workflows.

## Test Notes/Sample Code
<!--- Notes about testing or code to reproduce new functionality --->

## Connected Issues
<!--- Links to issues, using "Closes #NNN" if the issue is closed via PR --->

- Closes #62