### PR TITLE
Gsm.reporting v1.1.6 rc

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,5 @@
 # name: R-CMD-check.yaml
-# version: 0.4.1
+# version: 0.4.2
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Description: R CMD check for PRs
 on:
@@ -52,6 +52,7 @@ jobs:
           extra-packages: any::rcmdcheck
           needs: check
       - name: Set GITHUB_PAT
+        shell: bash
         run: echo "GITHUB_PAT=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
       - name: Check package
         uses: gilead-biostats/gsm.utils/check-r-package@actions-v1

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,5 +1,5 @@
 # name: R-CMD-check.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Description: R CMD check for PRs
 on:
@@ -21,7 +21,7 @@ jobs:
         with:
           pkg-use: 'public'
   R-CMD-check:
-    needs: setup-matrix
+    needs: [setup-matrix]
     runs-on: ${{ matrix.config.os }}
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
     strategy:
@@ -29,20 +29,30 @@ jobs:
       matrix:
         config: ${{ fromJSON(needs.setup-matrix.outputs.matrix) }}
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
+      - name: Generate token
+        uses: gilead-biostats/gsm.utils/generate-token@actions-v1
+        id: token
+        with:
+          app-id: ${{ secrets.CM_BOT_APP_ID }}
+          app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
       - name: Check out repo
         uses: gilead-biostats/gsm.utils/checkout@actions-v1
+        with:
+          token: ${{ steps.token.outputs.token }}
       - name: Install R and dependencies
         uses: gilead-biostats/gsm.utils/install@actions-v1
         with:
-          token: ${{ env.GITHUB_PAT }}
+          token: ${{ steps.token.outputs.token }}
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
           extra-packages: any::rcmdcheck
           needs: check
+      - name: Set GITHUB_PAT
+        run: echo "GITHUB_PAT=${{ steps.token.outputs.token }}" >> $GITHUB_ENV
       - name: Check package
         uses: gilead-biostats/gsm.utils/check-r-package@actions-v1
         with:

--- a/.github/workflows/pkgdown-all.yaml
+++ b/.github/workflows/pkgdown-all.yaml
@@ -1,5 +1,5 @@
 # name: pkgdown-all.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Description: Triggers the core pkgdown deployment and cleanup workflows.
 name: pkgdown-all
 on:
@@ -38,3 +38,5 @@ jobs:
       pkgdown-dev-mode: ${{ inputs.pkgdown-dev-mode == true }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,5 @@
 # name: qcthat.yaml
-# version: 0.1.0
+# version: 0.2.1
 # Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
@@ -43,6 +43,8 @@ jobs:
     uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      qcthat-app-id: ${{ secrets.CM_BOT_APP_ID }}
+      qcthat-app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}
     with:
       # Configuration variables for controlling workflow behavior
       manage-uat: true

--- a/.github/workflows/qcthat.yaml
+++ b/.github/workflows/qcthat.yaml
@@ -1,5 +1,6 @@
-# Workflow derived from
-# https://github.com/Gilead-BioStats/qcthat/tree/v1.1.1/inst/workflows/qcthat.yaml.
+# name: qcthat.yaml
+# version: 0.1.0
+# Description: Generate qcthat quality control reports for pull requests and releases and manage user acceptance testing.
 on:
   pull_request:
     types: [opened, edited, reopened, synchronize, milestoned]
@@ -9,20 +10,18 @@ on:
     types: [closed]
   workflow_dispatch:
     inputs:
-      pr:
+      pr-number:
         description: PR number to which reports should be added (leave blank for none).
-        required: false
       milestone:
-        description: Milestone name to use for the milestone report (leave blank for none).
-        required: false
+        description: Milestone name to use to target the milestone report (leave blank for none).
       tag:
         description: Release tag to which the report should be attached (leave blank for none).
-        required: false
-      issueNumber:
+      qcthat-ref:
+        description: A specific qcthat GitHub reference, such as a tag ("@v1.0.0"), branch ("@dev"), commit ("@480c247"), or pull request number ("#312") to use for reports and UAT management. Defaults to the latest release, "@*release".
+      issue-number:
         description: The closed issue number to process to update user acceptance testing information.
-        required: false
 
-name: qcthat Quality Control
+name: qcthat
 
 permissions:
   # read: Required for generating reports and updating UAT status.
@@ -36,123 +35,28 @@ permissions:
   # write: Required for updating UAT status.
   actions: write
 
-# Configuration variables for controlling workflow behavior
-env:
-  qcthat_UAT: true
-  qcthat_PR_REPORT: true
-  qcthat_COMPLETED_REPORT: true
-  qcthat_MILESTONE_REPORT: true
-  qcthat_RELEASE_REPORT: true
-  qcthat_FAIL_FOR_TEST_FAILURES: true
-
 jobs:
   qcthat:
-    runs-on: ubuntu-latest
     if: >-
       (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
       github.event_name != 'issues'
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: local::. Gilead-BioStats/qcthat@main
-
-      - name: Manage User Acceptance Testing
-        if: >-
-          env.qcthat_UAT == 'true' && (
-            (github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'qcthat-uat')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber != '')
-          )
-        run: |
-          Rscript -e "qcthat::TriggerUAT()"
-
-      - name: Generate Issue-Test Matrix
-        if: >-
-          (env.qcthat_PR_REPORT == 'true' || env.qcthat_RELEASE_REPORT == 'true' || env.qcthat_FAIL_FOR_TEST_FAILURES == 'true') && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          # Generate the full matrix for the package
-          IssueTestMatrix <- qcthat::QCPackage()
-          print(IssueTestMatrix)
-
-          # Save the matrix and UAT data for subsequent steps
-          saveRDS(IssueTestMatrix, "ITM.rds")
-          qcthat::SaveUATIssues()
-        shell: Rscript {0}
-
-      - name: Update PR Reports
-        if: >-
-          env.qcthat_PR_REPORT == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::CommentAllReports(
-            dfITM = issueTestMatrix,
-            lglPR = as.logical("${{ env.qcthat_PR_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}"),
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglUAT = as.logical("${{ env.qcthat_UAT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Update Release Reports
-        if: >-
-          env.qcthat_RELEASE_REPORT == 'true' && (
-            github.event_name == 'release' || inputs.tag != ''
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          qcthat::LoadUATIssues()
-          qcthat::AttachReleaseReports(
-            dfITM = issueTestMatrix,
-            lglCompleted = as.logical("${{ env.qcthat_COMPLETED_REPORT }}"),
-            lglMilestone = as.logical("${{ env.qcthat_MILESTONE_REPORT }}")
-          )
-        shell: Rscript {0}
-
-      - name: Flag failure for PR
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            (github.event_name == 'workflow_dispatch' && inputs.pr != '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfPR <- qcthat::QCPR(dfITM = issueTestMatrix)
-          if (any(dfPR$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for PR-associated issues."
-            )
-          }
-        shell: Rscript {0}
-
-      - name: Flag failure for completed
-        if: >-
-          env.qcthat_FAIL_FOR_TEST_FAILURES == 'true' && (
-            github.event_name == 'pull_request' ||
-            github.event_name == 'release' ||
-            (github.event_name == 'workflow_dispatch' && inputs.issueNumber == '')
-          )
-        run: |
-          issueTestMatrix <- readRDS("ITM.rds")
-          dfCompleted = qcthat::QCCompletedIssues(dfITM = issueTestMatrix)
-          if (any(dfCompleted$Disposition == "fail", na.rm = TRUE)) {
-            cli::cli_abort(
-              "One or more tests failed or were skipped for completed issues."
-            )
-          }
-        shell: Rscript {0}
+    uses: Gilead-BioStats/qcthat/.github/workflows/qcthat-core.yaml@actions
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      # Configuration variables for controlling workflow behavior
+      manage-uat: true
+      generate-pr-report: true
+      generate-completed-report: true
+      generate-milestone-report: true
+      generate-release-report: true
+      fail-for-test-failures: true
+      fail-for-missing-tests: true
+      uat-assignees: ${{ (github.event_name == 'pull_request' && github.base_ref == 'main' && 'jwildfire') || (github.event_name == 'pull_request' && github.base_ref != 'main' && 'lauramaxwell,nandriychuk') || '' }}
+      # Event context passed through to the core workflow
+      has-uat-label: ${{ contains(github.event.issue.labels.*.name, 'qcthat-uat') }}
+      pr-number: ${{ github.event.pull_request.number || inputs.pr-number || '' }}
+      milestone: ${{ github.event.pull_request.milestone.title || inputs.milestone || '' }}
+      tag: ${{ github.event.release.tag_name || inputs.tag || '' }}
+      issue-number: ${{ github.event.issue.number || inputs.issue-number || '' }}
+      qcthat-ref: ${{ inputs.qcthat-ref || '@*release' }}

--- a/.github/workflows/r-releaser-caller.yaml
+++ b/.github/workflows/r-releaser-caller.yaml
@@ -1,5 +1,5 @@
 # name: r-releaser-caller.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Description: R package release workflow
 name: Release
 
@@ -22,3 +22,5 @@ jobs:
       tag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,5 +1,5 @@
 # name: test-coverage.yaml
-# version: 0.3.8
+# version: 0.4.1
 # Description: Compute test coverage and publish coverage-summary.json artifact
 name: test-coverage
 on:
@@ -21,3 +21,5 @@ jobs:
     uses: Gilead-BioStats/gsm.utils/.github/workflows/test-coverage-core.yaml@actions-v1
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/workflow-template-check.yaml
+++ b/.github/workflows/workflow-template-check.yaml
@@ -1,18 +1,27 @@
 # name: workflow-template-check.yaml
-# version: 0.4.1
+# version: 0.5.0
 # Description: Check if GitHub Actions workflows match gsm.utils templates
 name: Workflow Template Compliance Check
 on:
   pull_request:
     branches: [main, release, dev]
     types: [opened, synchronize, reopened]
+  schedule:
+    - cron: '0 11 * * *'
+  repository_dispatch:
+    types: [workflow-templates-updated]
+  workflow_dispatch:
 permissions:
-  # Required to write comments on the pull request and view files
   pull-requests: write
-  contents: read
+  contents: write
 jobs:
   check-workflows:
     uses: Gilead-BioStats/gsm.utils/.github/workflows/workflow-template-checker.yaml@actions-v1
+    with:
+      default-branch: ${{ github.event.repository.default_branch }}
+      pr-number: '${{ github.event.number }}'
+      event-name: ${{ github.event_name }}
+      is-fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
     secrets:
       app-id: ${{ secrets.CM_BOT_APP_ID }}
       app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/.github/workflows/workflow-template-check.yaml
+++ b/.github/workflows/workflow-template-check.yaml
@@ -1,5 +1,5 @@
 # name: workflow-template-check.yaml
-# version: 0.3.6
+# version: 0.4.1
 # Description: Check if GitHub Actions workflows match gsm.utils templates
 name: Workflow Template Compliance Check
 on:
@@ -13,3 +13,6 @@ permissions:
 jobs:
   check-workflows:
     uses: Gilead-BioStats/gsm.utils/.github/workflows/workflow-template-checker.yaml@actions-v1
+    secrets:
+      app-id: ${{ secrets.CM_BOT_APP_ID }}
+      app-private-key: ${{ secrets.CM_BOT_PRIVATE_KEY }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gsm.reporting
 Title: Good Statistical Monitoring Reporting
-Version: 1.1.5
+Version: 1.1.6
 Authors@R: c(
     person("Jeremy", "Wildfire", , "jwildfire@gmail.com", role = c("aut", "cre")),
     person("Laura", "Maxwell", , "lkmaxwell23@gmail.com", role = "aut"),
@@ -39,10 +39,10 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@main,
-    gsm.kri=Gilead-BioStats/gsm.kri@main,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@main,
-    workr=Gilead-BioStats/workr
+    gsm.core=Gilead-BioStats/gsm.core@gsm.core-v1.3.0-rc,
+    gsm.kri=Gilead-BioStats/gsm.kri@gsm.kri-v1.6.0-rc,
+    gsm.mapping=Gilead-BioStats/gsm.mapping@gsm.mapping-v1.1.5-rc,
+    workr=Gilead-BioStats/workr@rc-v1.1.0
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,13 +34,15 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
+    workr,
     withr
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@main,
-    gsm.kri=Gilead-BioStats/gsm.kri@main,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@main
+    gsm.core=Gilead-BioStats/gsm.core@workr-implementation,
+    gsm.kri=Gilead-BioStats/gsm.kri@workr-implementation,
+    gsm.mapping=Gilead-BioStats/gsm.mapping@workr-implementation,
+    workr=Gilead-BioStats/workr
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,9 +39,9 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@workr-implementation,
-    gsm.kri=Gilead-BioStats/gsm.kri@workr-implementation,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@workr-implementation,
+    gsm.core=Gilead-BioStats/gsm.core@dev,
+    gsm.kri=Gilead-BioStats/gsm.kri@dev,
+    gsm.mapping=Gilead-BioStats/gsm.mapping@dev,
     workr=Gilead-BioStats/workr
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,9 +39,9 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@dev,
-    gsm.kri=Gilead-BioStats/gsm.kri@dev,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@dev,
+    gsm.core=Gilead-BioStats/gsm.core@main,
+    gsm.kri=Gilead-BioStats/gsm.kri@main,
+    gsm.mapping=Gilead-BioStats/gsm.mapping@main,
     workr=Gilead-BioStats/workr
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,10 +39,10 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@gsm.core-v1.3.0-rc,
-    gsm.kri=Gilead-BioStats/gsm.kri@gsm.kri-v1.6.0-rc,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@gsm.mapping-v1.1.5-rc,
-    workr=Gilead-BioStats/workr@rc-v1.1.0,
+    gsm.core=Gilead-BioStats/gsm.core@main,
+    gsm.kri=Gilead-BioStats/gsm.kri@main,
+    gsm.mapping=Gilead-BioStats/gsm.mapping@main,
+    workr=Gilead-BioStats/workr@main,
     log4r=r-lib/log4r
 Config/testthat/edition: 3
 Config/testthat/parallel: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,8 @@ Remotes:
     gsm.core=Gilead-BioStats/gsm.core@gsm.core-v1.3.0-rc,
     gsm.kri=Gilead-BioStats/gsm.kri@gsm.kri-v1.6.0-rc,
     gsm.mapping=Gilead-BioStats/gsm.mapping@gsm.mapping-v1.1.5-rc,
-    workr=Gilead-BioStats/workr@rc-v1.1.0
+    workr=Gilead-BioStats/workr@rc-v1.1.0,
+    log4r=r-lib/log4r
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ Imports:
     purrr,
     tibble,
     tidyr,
+    workr,
     yaml
 Suggests:
     DT,
@@ -34,7 +35,6 @@ Suggests:
     knitr,
     rmarkdown,
     testthat (>= 3.0.0),
-    workr,
     withr
 VignetteBuilder: 
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# gsm.reporting 1.1.6
+
+This release migrates workflow orchestration to the new `workr` package and improves how metric metadata flows through to reports.
+
+**Changes:**
+- Workflow orchestration functions (such as `MakeWorkflowList()` and `RunWorkflows()`) are now provided by the new `workr` package. Documentation and examples have been updated to reference `workr::` in place of `gsm.core::`.
+- `MakeMetric()` now passes through all metadata fields defined on a workflow (for example `Active` and `GenerateRiskSignal`), so custom metadata is preserved in the metrics data used by charts and reports ([#62](https://github.com/Gilead-BioStats/gsm.reporting/issues/62)).
+- The bundled reporting workflows (Bounds, Groups, Metrics, Results) now set `Active: true` so they are included by default when running the reporting pipeline.
+
 # gsm.reporting 1.1.5
 
 This patch release updates the GitHub action workflows to align with the new federated action framework in `gsm.utils`

--- a/R/BindResults.R
+++ b/R/BindResults.R
@@ -4,11 +4,11 @@
 #' `r lifecycle::badge("stable")`
 #'
 #' Used to stack results (e.g. `dfSummary`) from a list of analysis pipeline
-#' output formatted like the result of `RunWorkflows()`. Also adds study level
-#' metadata when provided.
+#' output formatted like the result of [workr::RunWorkflows()]. Also adds study
+#' level metadata when provided.
 #'
 #' @param lAnalysis Named List of analysis results in the format returned by
-#'   [RunWorkflows()].
+#'   [workr::RunWorkflows()].
 #' @param strName Name of the object to stack. Pulled from `lAnalysis` (or from
 #'   `lAnalysis$lData` when `bUselData` is `TRUE`).
 #' @param dSnapshotDate Date of the snapshot. Default is [Sys.Date()].

--- a/R/MakeMetric.R
+++ b/R/MakeMetric.R
@@ -8,14 +8,13 @@
 #' per `MetricID`.
 #'
 #' @param lWorkflows A list of workflows, like the one returned by
-#'   [gsm.core::MakeWorkflowList()].
+#'   [workr::MakeWorkflowList()].
 #'
 #' @return A data frame.
 #'
 #' @examples
 #' \dontrun{
-#' library(gsm.core)
-#' lWorkflows <- MakeWorkflowList(
+#' lWorkflows <- workr::MakeWorkflowList(
 #'   strPath = "workflow/2_metrics",
 #'   strNames = "kri",
 #'   strPackage = "gsm.kri"

--- a/inst/workflow/3_reporting/Bounds.yaml
+++ b/inst/workflow/3_reporting/Bounds.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Bounds
   Description: Generate reporting data model including site-, country- and study-level metadata (dfGroups), metric metadata (dfMetrics) and results data with added study-level columsn (dfSummary and dfBounds).
   Priority: 2
+  Active: true
 spec:
   Reporting_Results:
     _all:

--- a/inst/workflow/3_reporting/Groups.yaml
+++ b/inst/workflow/3_reporting/Groups.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Groups
   Description: Reporting Groups Data
   Priority: 1
+  Active: true
 spec:
   Mapped_STUDY:
     _all:

--- a/inst/workflow/3_reporting/Metrics.yaml
+++ b/inst/workflow/3_reporting/Metrics.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Metrics
   Description: Reporting Metrics Data
   Priority: 1
+  Active: true
 steps:
   # lWorkflows is a named list of metric workflows.
   - output: Reporting_Metrics

--- a/inst/workflow/3_reporting/Results.yaml
+++ b/inst/workflow/3_reporting/Results.yaml
@@ -3,6 +3,7 @@ meta:
   ID: Results
   Description: Reporting Results Data
   Priority: 1
+  Active: true
 spec:
   Mapped_STUDY:
     GroupID:

--- a/man/BindResults.Rd
+++ b/man/BindResults.Rd
@@ -14,7 +14,7 @@ BindResults(
 }
 \arguments{
 \item{lAnalysis}{Named List of analysis results in the format returned by
-\code{\link[gsm.core:RunWorkflows]{gsm.core::RunWorkflows()}}.}
+\code{\link[workr:RunWorkflows]{workr::RunWorkflows()}}.}
 
 \item{strName}{Name of the object to stack. Pulled from \code{lAnalysis} (or from
 \code{lAnalysis$lData} when \code{bUselData} is \code{TRUE}).}
@@ -33,6 +33,6 @@ A data frame.
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
 
 Used to stack results (e.g. \code{dfSummary}) from a list of analysis pipeline
-output formatted like the result of \code{RunWorkflows()}. Also adds study level
-metadata when provided.
+output formatted like the result of \code{\link[workr:RunWorkflows]{workr::RunWorkflows()}}. Also adds study
+level metadata when provided.
 }

--- a/man/MakeMetric.Rd
+++ b/man/MakeMetric.Rd
@@ -8,7 +8,7 @@ MakeMetric(lWorkflows)
 }
 \arguments{
 \item{lWorkflows}{A list of workflows, like the one returned by
-\code{\link[gsm.core:MakeWorkflowList]{gsm.core::MakeWorkflowList()}}.}
+\code{\link[workr:MakeWorkflowList]{workr::MakeWorkflowList()}}.}
 }
 \value{
 A data frame.
@@ -22,8 +22,7 @@ per \code{MetricID}.
 }
 \examples{
 \dontrun{
-library(gsm.core)
-lWorkflows <- MakeWorkflowList(
+lWorkflows <- workr::MakeWorkflowList(
   strPath = "workflow/2_metrics",
   strNames = "kri",
   strPackage = "gsm.kri"

--- a/tests/testthat/helper-qual_data.R
+++ b/tests/testthat/helper-qual_data.R
@@ -55,7 +55,7 @@ lData <- list(
 domains <- c(gsub("Raw_", "", names(lData)), "COUNTRY", "EXCLUSION")
 
 ## Get Mapped data
-mappings_wf <- MakeWorkflowList(
+mappings_wf <- workr::MakeWorkflowList(
   strNames = domains,
   strPath = file.path(
     system.file(package = "gsm.mapping"),
@@ -69,7 +69,7 @@ gsm.core::SetLogger(log4r::logger(
   threshold = "ERROR",
   appenders = ConsoleAppender
 ))
-mapped_data <- RunWorkflows(mappings_wf, lData)
+mapped_data <- workr::RunWorkflows(mappings_wf, lData)
 gsm.core::SetLogger(log4r::logger(
   "DEBUG",
   appenders = ConsoleAppender

--- a/tests/testthat/test-MakeMetric.R
+++ b/tests/testthat/test-MakeMetric.R
@@ -1,3 +1,55 @@
+test_that("MakeMetric includes Active column when present in meta (#62)", {
+  given <- list(
+    a = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0001",
+        GroupLevel = "Site",
+        Abbreviation = "AE",
+        Active = TRUE
+      )
+    ),
+    b = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0002",
+        GroupLevel = "Site",
+        Abbreviation = "SAE",
+        Active = FALSE
+      )
+    )
+  )
+  result <- MakeMetric(given)
+  expect_true("Active" %in% names(result))
+  expect_identical(result$Active, c(TRUE, FALSE))
+})
+
+test_that("MakeMetric includes GenerateRiskSignal column when present in meta (#62)", {
+  given <- list(
+    a = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0001",
+        GroupLevel = "Site",
+        Abbreviation = "AE",
+        GenerateRiskSignal = TRUE
+      )
+    ),
+    b = list(
+      meta = list(
+        Type = "Metric",
+        ID = "kri0002",
+        GroupLevel = "Site",
+        Abbreviation = "SAE",
+        GenerateRiskSignal = FALSE
+      )
+    )
+  )
+  result <- MakeMetric(given)
+  expect_true("GenerateRiskSignal" %in% names(result))
+  expect_identical(result$GenerateRiskSignal, c(TRUE, FALSE))
+})
+
 test_that("MakeMetric makes dfMetrics", {
   given <- list(
     a = list(

--- a/tests/testthat/test-qual_T15_1.R
+++ b/tests/testthat/test-qual_T15_1.R
@@ -1,13 +1,13 @@
 testthat::skip_if_not_installed("gsm.kri")
 TestAtLogLevel("WARN")
 ## Test Setup
-kri_workflows <- gsm.core::MakeWorkflowList(
+kri_workflows <- workr::MakeWorkflowList(
   strNames = c("kri", "srs"),
   strPath = "workflow/2_metrics",
   strPackage = "gsm.kri"
 )
-reporting_workflows <- gsm.core::MakeWorkflowList(strPath =  file.path(system.file(package = "gsm.reporting"), "workflow", "3_reporting"))
-analyzed <- gsm.core::RunWorkflows(
+reporting_workflows <- workr::MakeWorkflowList(strPath =  file.path(system.file(package = "gsm.reporting"), "workflow", "3_reporting"))
+analyzed <- workr::RunWorkflows(
   kri_workflows,
   lData = c(mapped_data, list(lWorkflows = kri_workflows))
 ) %>%
@@ -18,7 +18,7 @@ outputs <- map(reporting_workflows, \(x) x$steps[[length(x$steps)]]$output)
 testthat::test_that("Qual: Given summarized analytics data, a properly specified reporting workflow creates cross-sectional results data set with one record per metric per group  (#50)", {
   expect_message(
     {
-      test <- RunWorkflows(
+      test <- workr::RunWorkflows(
         reporting_workflows,
         lData = c(
           mapped_data,

--- a/tests/testthat/test-qual_T15_1.R
+++ b/tests/testthat/test-qual_T15_1.R
@@ -6,7 +6,7 @@ kri_workflows <- workr::MakeWorkflowList(
   strPath = "workflow/2_metrics",
   strPackage = "gsm.kri"
 )
-reporting_workflows <- workr::MakeWorkflowList(strPath =  file.path(system.file(package = "gsm.reporting"), "workflow", "3_reporting"))
+reporting_workflows <- workr::MakeWorkflowList(strPath = file.path(system.file(package = "gsm.reporting"), "workflow", "3_reporting"))
 analyzed <- workr::RunWorkflows(
   kri_workflows,
   lData = c(mapped_data, list(lWorkflows = kri_workflows))

--- a/tests/testthat/test-qual_T15_2.R
+++ b/tests/testthat/test-qual_T15_2.R
@@ -1,19 +1,19 @@
 testthat::skip_if_not_installed("gsm.kri")
 TestAtLogLevel("WARN")
 ## Test Setup
-kri_workflows <- gsm.core::MakeWorkflowList(
+kri_workflows <- workr::MakeWorkflowList(
   strNames = c("kri", "srs"),
   strPath = "workflow/2_metrics",
   strPackage = "gsm.kri"
 )
-reporting_workflows <- gsm.core::MakeWorkflowList(
+reporting_workflows <- workr::MakeWorkflowList(
   strPath = file.path(
     system.file(package = "gsm.reporting"),
     "workflow",
     "3_reporting"
   )
 )
-analyzed <- gsm.core::RunWorkflows(
+analyzed <- workr::RunWorkflows(
   kri_workflows,
   lData = c(mapped_data, list(lWorkflows = kri_workflows))
 ) %>%
@@ -23,7 +23,7 @@ historical_reporting_results <- gsm.core::reportingResults %>%
   dplyr::filter(SnapshotDate < max(.data$SnapshotDate))
 ## Test Code
 testthat::test_that("Qual: Given summarized analytics data and historical reporting results data, a properly specified reporting workflow creates cross-sectional results data set including changes from previous snapshot with one record per metric per group (#6, #30, #31, #35, #50)", {
-  test <- RunWorkflows(
+  test <- workr::RunWorkflows(
     reporting_workflows,
     lData = c(
       mapped_data,

--- a/tests/testthat/test-workr-migration.R
+++ b/tests/testthat/test-workr-migration.R
@@ -1,0 +1,27 @@
+# Qualification test for gsm.reporting#64.
+#
+# The workflow-runtime entry points were re-pointed from {gsm.core} to {workr}.
+# This test exercises that contract directly: the package's reporting workflow
+# specs load and parse through workr::MakeWorkflowList() (the migrated runtime
+# home). Staying analytics functions (Analyze_*, Summarize, etc.) remain on
+# gsm.core:: and are out of scope here.
+
+test_that("reporting workflow specs load through the workr runtime (#64)", {
+  wf_dir <- file.path(
+    system.file(package = "gsm.reporting"),
+    "workflow",
+    "3_reporting"
+  )
+  skip_if(!dir.exists(wf_dir), "reporting workflow specs not found")
+
+  reporting_workflows <- workr::MakeWorkflowList(strPath = wf_dir)
+
+  expect_type(reporting_workflows, "list")
+  expect_gt(length(reporting_workflows), 0)
+  # Each loaded workflow exposes runtime steps (the workr workflow contract).
+  expect_true(all(vapply(
+    reporting_workflows,
+    function(w) length(w$steps) > 0,
+    logical(1)
+  )))
+})

--- a/tests/testthat/test-workr-migration.R
+++ b/tests/testthat/test-workr-migration.R
@@ -6,20 +6,20 @@
 # home). Staying analytics functions (Analyze_*, Summarize, etc.) remain on
 # gsm.core:: and are out of scope here.
 
-test_that("reporting workflow specs load through the workr runtime (#64)", {
+testthat::test_that("reporting workflow specs load through the workr runtime (#64)", {
   wf_dir <- file.path(
     system.file(package = "gsm.reporting"),
     "workflow",
     "3_reporting"
   )
-  skip_if(!dir.exists(wf_dir), "reporting workflow specs not found")
+  testthat::skip_if(!dir.exists(wf_dir), "reporting workflow specs not found")
 
   reporting_workflows <- workr::MakeWorkflowList(strPath = wf_dir)
 
-  expect_type(reporting_workflows, "list")
-  expect_gt(length(reporting_workflows), 0)
+  testthat::expect_type(reporting_workflows, "list")
+  testthat::expect_gt(length(reporting_workflows), 0)
   # Each loaded workflow exposes runtime steps (the workr workflow contract).
-  expect_true(all(vapply(
+  testthat::expect_true(all(vapply(
     reporting_workflows,
     function(w) length(w$steps) > 0,
     logical(1)

--- a/vignettes/DataReporting.Rmd
+++ b/vignettes/DataReporting.Rmd
@@ -43,7 +43,7 @@ These functions and workflows produce data frames, visualizations, metadata, and
 
 ![](data_model_detailed.png){width="100%"}
 
-All of the functions to create the data frames in the reporting data model will run automatically and sequentially when a user specifies the metadata and data needed for the report, and calls `workr::RunWorkflow()` on the yaml files in the `workflow/3_reporting` directory. To create a report, the output of the reporting yamls is fed into the yamls in the `workflow/4_modules` directory to produce and html document with all charts and tables created in the reporting workflow. For a more detailed discussion of the yaml file and directory structure, see the [`{gsm.core}` Extensions vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html)`).
+All of the functions to create the data frames in the reporting data model will run automatically and sequentially when a user specifies the metadata and data needed for the report, and calls `workr::RunWorkflow()` on the YAML files in the `workflow/3_reporting` directory. To create a report, the output of the reporting YAMLs is fed into the YAMLs in the `workflow/4_modules` directory to produce an HTML document with all charts and tables created in the reporting workflow. For a more detailed discussion of the YAML file and directory structure, see the [`{gsm.core}` Extensions vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html).
 
 Each of the individual functions can also be run independently outside of a specified yaml workflow.
 

--- a/vignettes/DataReporting.Rmd
+++ b/vignettes/DataReporting.Rmd
@@ -43,7 +43,7 @@ These functions and workflows produce data frames, visualizations, metadata, and
 
 ![](data_model_detailed.png){width="100%"}
 
-All of the functions to create the data frames in the reporting data model will run automatically and sequentially when a user specifies the metadata and data needed for the report, and calls upon the `gsm.core::RunWorkflow()` function on the yaml files in the `workflow/3_reporting` directory. To create a report, the output of the reporting yamls is fed into the yamls in the `workflow/4_modules` directory to produce and html document with all charts and tables created in the reporting workflow. For a more detailed discussion of the yaml file and directory structure, see the [`{gsm.core}` Extensions vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html)`).
+All of the functions to create the data frames in the reporting data model will run automatically and sequentially when a user specifies the metadata and data needed for the report, and calls `workr::RunWorkflow()` on the yaml files in the `workflow/3_reporting` directory. To create a report, the output of the reporting yamls is fed into the yamls in the `workflow/4_modules` directory to produce and html document with all charts and tables created in the reporting workflow. For a more detailed discussion of the yaml file and directory structure, see the [`{gsm.core}` Extensions vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html)`).
 
 Each of the individual functions can also be run independently outside of a specified yaml workflow.
 
@@ -74,18 +74,18 @@ core_mappings <- c("AE", "COUNTRY", "DATACHG", "DATAENT", "ENROLL", "LB", "PK", 
 lSource <- gsm.core::lSource
 
 # Step 0 - Data Ingestion - standardize tables/columns names
-mappings_wf <- MakeWorkflowList(strPath = "workflow/1_mappings", 
-                                strNames = core_mappings,
-                                strPackage = "gsm.mapping")
+mappings_wf <- workr::MakeWorkflowList(strPath = "workflow/1_mappings", 
+                                       strNames = core_mappings,
+                                       strPackage = "gsm.mapping")
 mappings_spec <- CombineSpecs(mappings_wf)
 lRaw <- Ingest(lSource, mappings_spec)
 
 # Step 1 - Create Mapped Data Layer - filter, aggregate and join raw data to create mapped data layer
-mapped <- RunWorkflows(mappings_wf, lRaw)
+mapped <- workr::RunWorkflows(mappings_wf, lRaw)
 
 # Step 2 - Create Metrics - calculate metrics using mapped data
-metrics_wf <- MakeWorkflowList(strPath = "workflow/2_metrics", strNames = "kri", strPackage = "gsm.kri")
-lAnalysis <- RunWorkflows(metrics_wf, mapped)
+metrics_wf <- workr::MakeWorkflowList(strPath = "workflow/2_metrics", strNames = "kri", strPackage = "gsm.kri")
+lAnalysis <- workr::RunWorkflows(metrics_wf, mapped)
 ```
 
 
@@ -106,28 +106,28 @@ The following sub-steps will dive into the creation and structure of each of the
 
 #### Step 1.1 - Transform CTMS data into `dfGroups` data frame
 
-The `dfGroups` data frame is critical to providing site-, study- and country-level information in the final report. This table is based on CTMS data and the mapped `dfEnrolled` data frame created in the Analysis workflow. Creating this table requires the creation of 5 smaller tables that summarize the data at each group level using `RunQuery()` and `MakeLongMeta()`. These small tables are then bound together to create `dfGroups`.
+The `dfGroups` data frame is critical to providing site-, study- and country-level information in the final report. This table is based on CTMS data and the mapped `dfEnrolled` data frame created in the Analysis workflow. Creating this table requires the creation of 5 smaller tables that summarize the data at each group level using `workr::RunQuery()` and `MakeLongMeta()`. These small tables are then bound together to create `dfGroups`.
 
 ```{r include = TRUE, message = FALSE}
 #Transform CTMS Site and Study Level data
-dfCTMSSite <- gsm.core::RunQuery(df = lSource$Raw_SITE, 
+dfCTMSSite <- workr::RunQuery(df = lSource$Raw_SITE, 
                                  strQuery = "SELECT pi_number as GroupID, site_status as Status, pi_first_name as InvestigatorFirstName, pi_last_name as InvestigatorLastName, city as City, state as State, country as Country, * FROM df") |>
   gsm.mapping::MakeLongMeta(strGroupLevel = 'Site')
 
-dfCTMSStudy <- gsm.core::RunQuery(df = lSource$Raw_STUDY,
+dfCTMSStudy <- workr::RunQuery(df = lSource$Raw_STUDY,
                                   strQuery = "SELECT protocol_number as GroupID, status as Status, * FROM df") |>
   gsm.mapping::MakeLongMeta(strGroupLevel = 'Study')
 
 # Get Participant and Site counts for Country, Site and Study
-dfSiteCounts <- gsm.core::RunQuery(df = mapped$Mapped_SUBJ,
+dfSiteCounts <- workr::RunQuery(df = mapped$Mapped_SUBJ,
                                    strQuery = "SELECT invid as GroupID, COUNT(DISTINCT subjid) as ParticipantCount, COUNT(DISTINCT invid) as SiteCount FROM df GROUP BY invid") |>
   gsm.mapping::MakeLongMeta(strGroupLevel = "Site")
 
-dfStudyCounts <- gsm.core::RunQuery(df = mapped$Mapped_SUBJ,
+dfStudyCounts <- workr::RunQuery(df = mapped$Mapped_SUBJ,
                              strQuery = "SELECT studyid as GroupID, COUNT(DISTINCT subjid) as ParticipantCount, COUNT(DISTINCT invid) as SiteCount FROM df GROUP BY studyid") |>
   gsm.mapping::MakeLongMeta(strGroupLevel = "Study")
 
-dfCountryCounts <- gsm.core::RunQuery(df = mapped$Mapped_SUBJ,
+dfCountryCounts <- workr::RunQuery(df = mapped$Mapped_SUBJ,
                              strQuery = "SELECT country as GroupID, COUNT(DISTINCT subjid) as ParticipantCount, COUNT(DISTINCT invid) as SiteCount FROM df GROUP BY country") |>
   gsm.mapping::MakeLongMeta(strGroupLevel = "Country")
 
@@ -304,30 +304,30 @@ core_mappings <- c("AE", "COUNTRY", "DATACHG", "DATAENT", "ENROLL", "LB", "PK", 
 lSource <- gsm.core::lSource
 
 # Step 0 - Data Ingestion - standardize tables/columns names
-mappings_wf <- gsm.core::MakeWorkflowList(strNames = core_mappings, strPath = "workflow/1_mappings", strPackage = "gsm.mapping")
+mappings_wf <- workr::MakeWorkflowList(strNames = core_mappings, strPath = "workflow/1_mappings", strPackage = "gsm.mapping")
 mappings_spec <- gsm.mapping::CombineSpecs(mappings_wf)
 lRaw <- gsm.mapping::Ingest(lSource, mappings_spec)
 
 # Step 1 - Create Mapped Data Layer - filter, aggregate and join raw data to create mapped data layer
-mapped <- gsm.core::RunWorkflows(mappings_wf, lRaw)
+mapped <- workr::RunWorkflows(mappings_wf, lRaw)
 
 # Step 2 - Create Metrics - calculate metrics using mapped data
-metrics_wf <- gsm.core::MakeWorkflowList(strPath = "workflow/2_metrics", strPackage = "gsm.kri")
-analyzed <- gsm.core::RunWorkflows(metrics_wf, mapped)
+metrics_wf <- workr::MakeWorkflowList(strPath = "workflow/2_metrics", strPackage = "gsm.kri")
+analyzed <- workr::RunWorkflows(metrics_wf, mapped)
 
 # Step 3 - Create Reporting Layer - create reports using metrics data
-reporting_wf <- gsm.core::MakeWorkflowList(strPath = "workflow/3_reporting", strPackage = "gsm.reporting")
-reporting <- gsm.core::RunWorkflows(reporting_wf, c(mapped, list(lAnalyzed = analyzed, lWorkflows = metrics_wf)))
+reporting_wf <- workr::MakeWorkflowList(strPath = "workflow/3_reporting", strPackage = "gsm.reporting")
+reporting <- workr::RunWorkflows(reporting_wf, c(mapped, list(lAnalyzed = analyzed, lWorkflows = metrics_wf)))
 
 # Step 4 - Create KRI Report - create KRI report using reporting data
-module_wf <- gsm.core::MakeWorkflowList(strPath = "workflow/4_modules", strPackage = "gsm.kri")
-lReports <- gsm.core::RunWorkflows(module_wf, reporting)
+module_wf <- workr::MakeWorkflowList(strPath = "workflow/4_modules", strPackage = "gsm.kri")
+lReports <- workr::RunWorkflows(module_wf, reporting)
 ```
 
 ----------------------------------------------------------------
 ## Incorporating Historical data into the Reporting Output
 
-Using the output from the section above, you can modify the reporting workflow to include historical data by feeding the historical data into `gsm.core::RunWorkflows` as a component of the `lData` argument. 
+Using the output from the section above, you can modify the reporting workflow to include historical data by feeding the historical data into `workr::RunWorkflows` as a component of the `lData` argument. 
 
 By including the `Reporting_Results_Longitudinal` data.frame, the `CalculateChange()` function is triggered. This function calculates the change in the value (`_Change`) and the percentage change in the value (`_PercentChange`) between the previous snapshot and the current snapshot for all Reporting Result metrics.  This is useful for longitudinal studies where you want to compare current results with past snapshots.
 
@@ -336,11 +336,11 @@ By including the `Reporting_Results_Longitudinal` data.frame, the `CalculateChan
 historical <- gsm.core::reportingResults %>% filter(SnapshotDate == "2025-03-01")
 
 # Re-run reporting model and KRI report with historical data
-reporting_long <- gsm.core::RunWorkflows(reporting_wf, 
+reporting_long <- workr::RunWorkflows(reporting_wf, 
                                          lData = c(mapped, list(lAnalyzed = analyzed, 
                                                                 Reporting_Results_Longitudinal = historical, 
                                                                 lWorkflows = metrics_wf)))
-lReports_long <- gsm.core::RunWorkflows(module_wf, reporting_long)
+lReports_long <- workr::RunWorkflows(module_wf, reporting_long)
 ```
 
 Reporting data with this historical trend will produce an additional section of the KRI report which highlights the "Flags Changed" from the previous snapshot to the current snapshot. This section will look like the following:
@@ -350,7 +350,7 @@ Reporting data with this historical trend will produce an additional section of 
     
 ### Recap - Reporting Workflow 
     
-  -   `dfGroups` created from CTMS data using `RunQuery()`, `MakeLongMeta()` and `bind_rows()`
+  -   `dfGroups` created from CTMS data using `workr::RunQuery()`, `MakeLongMeta()` and `bind_rows()`
   -   `dfMetrics` created from `lWorkflow` using `MakeMetric()`
   -   `dfResults` created from `lAnalysis$dfSummary` using `BindResults()`
   -   `dfBounds` created from `dfResults` using `MakeBounds()`
@@ -364,7 +364,7 @@ Reporting data with this historical trend will produce an additional section of 
   
 ### Mapping Functions
   
-  -   `gsm.core::RunQuery()`: Run a SQL query to create new data.frames with filtering and column name specifications.
+  -   `workr::RunQuery()`: Run a SQL query to create new data.frames with filtering and column name specifications.
   
 
 ### Visualization Functions


### PR DESCRIPTION
# gsm.reporting 1.1.6

This release migrates workflow orchestration to the new `workr` package and improves how metric metadata flows through to reports.

**Changes:**
- Workflow orchestration functions (such as `MakeWorkflowList()` and `RunWorkflows()`) are now provided by the new `workr` package. Documentation and examples have been updated to reference `workr::` in place of `gsm.core::`.
- `MakeMetric()` now passes through all metadata fields defined on a workflow (for example `Active` and `GenerateRiskSignal`), so custom metadata is preserved in the metrics data used by charts and reports ([#62](https://github.com/Gilead-BioStats/gsm.reporting/issues/62)).
- The bundled reporting workflows (Bounds, Groups, Metrics, Results) now set `Active: true` so they are included by default when running the reporting pipeline.