### PR TITLE
fix: update Gilead-BioStats links to Gilead-Public

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to the `gsm` suite of packages!
 
-This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).  
+This repository follows the **centralized `gsm` Contributor Guidelines** maintained in [`gsm.core`](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).  
 Please review those guidelines before opening issues or submitting pull requests.
 
 ## Key Points
@@ -12,4 +12,4 @@ Please review those guidelines before opening issues or submitting pull requests
 - Track your issue on the [`gsm` Roadmap Project Board](https://github.com/orgs/Gilead-BioStats/projects/41).  
 - All code changes should be made in a branch and submitted as a PR following the guidelines linked above.  
   
-For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-biostats.github.io/gsm.core/CONTRIBUTING.html).
+For detailed workflows (branching, releases, QC, CI/CD), please see the full [Contributor Guidelines in gsm.core](https://gilead-public.github.io/gsm.core/CONTRIBUTING.html).

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -8,7 +8,7 @@
 ## Milestone
 <!--- Link to the milestone for the release. ---> 
 <!--- Make sure all relevant issues/PRs are included on the linked pages. --->
-Milestone: [v1.0.0](https://github.com/Gilead-BioStats/gsm.reporting/milestone/1)
+Milestone: [v1.0.0](https://github.com/Gilead-Public/gsm.reporting/milestone/1)
 
 # Overall Risk Assessment 
 <!--- Complete the following Risk Assessment for this Release-->
@@ -45,6 +45,6 @@ Notes:
 - [ ] Formatted code with `styler`
 - [ ] Run `spell_check()`
 - [ ] Completed QC of documentation including `README.md` and relevant Vignettes
-- [ ] Build site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://gilead-biostats.github.io/gsm.reporting/reference/index.html)" page. 
+- [ ] Build site `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "[Reference](https://gilead-public.github.io/gsm.reporting/reference/index.html)" page. 
 - [ ] Draft GitHub release created using automatic template and updated with additional details. Remember to click "release" after PR is merged.  
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Description: The Good Statistical Monitoring or 'gsm' suite of R packages
     provides workflows to generate the reporting data model needed to
     generate reports.
 License: Apache License (>= 2)
-URL: https://gilead-biostats.github.io/gsm.reporting/,
-    https://github.com/Gilead-BioStats/gsm.reporting/
+URL: https://gilead-public.github.io/gsm.reporting/,
+    https://github.com/Gilead-Public/gsm.reporting/
 Imports: 
     cli,
     dplyr,
@@ -38,10 +38,10 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    gsm.core=Gilead-BioStats/gsm.core@dev,
-    gsm.kri=Gilead-BioStats/gsm.kri@dev,
-    gsm.mapping=Gilead-BioStats/gsm.mapping@dev,
-    workr=Gilead-BioStats/workr@main
+    gsm.core=Gilead-Public/gsm.core@dev,
+    gsm.kri=Gilead-Public/gsm.kri@dev,
+    gsm.mapping=Gilead-Public/gsm.mapping@dev,
+    workr=Gilead-Public/workr@main
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Encoding: UTF-8

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 <div class="pkgdown-release">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/R-CMD-check.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/test-coverage.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/pkgdown-all.yaml/badge.svg?branch=main)](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
 <div class="pkgdown-devel">
 
-[![R-CMD-check](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/R-CMD-check.yaml)
-[![test-coverage](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/test-coverage.yaml)
-[![pkgdown-all](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-BioStats/gsm.reporting/actions/workflows/pkgdown-all.yaml)
+[![R-CMD-check](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/R-CMD-check.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/R-CMD-check.yaml)
+[![test-coverage](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/test-coverage.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/test-coverage.yaml)
+[![pkgdown-all](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/pkgdown-all.yaml/badge.svg?branch=dev)](https://github.com/Gilead-Public/gsm.reporting/actions/workflows/pkgdown-all.yaml)
 
 </div>
 
@@ -30,7 +30,7 @@ The {gsm} ecosystem provides a standardized Risk Based Quality Monitoring (RBQM)
 
 
 The `{gsm.reporting}` package provides the necessary functions and workflows to produce the reporting data model that is used by many packages to produce visualizations and reports.
-This README provides a high-level overview of {gsm.reporting}; see the [gsm Reporting Vignette](https://gilead-biostats.github.io/gsm.reporting/gsmReporting.html) for additional details.
+This README provides a high-level overview of {gsm.reporting}; see the [gsm Reporting Vignette](https://gilead-public.github.io/gsm.reporting/gsmReporting.html) for additional details.
 
 With all necessary inputs to the reporting model created via functions in `{gsm.mapping}` and `{gsm.core}`, `{gsm.reporting}` generates the reporting data model data frames. These data frames created are as follows:
 
@@ -46,7 +46,7 @@ You can install the latest release of gsm.reporting from [GitHub](https://github
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.reporting@*release")
+pak::pak("Gilead-Public/gsm.reporting@*release")
 ```
 
 <div class="pkgdown-devel">
@@ -56,7 +56,7 @@ You can install the development version of gsm.reporting from
 
 ``` r
 # install.packages("pak")
-pak::pak("Gilead-BioStats/gsm.reporting")
+pak::pak("Gilead-Public/gsm.reporting")
 ```
 
 </div>

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://gilead-biostats.github.io/gsm.reporting/
+url: https://gilead-public.github.io/gsm.reporting/
 template:
   bootstrap: 5
   bootswatch: yeti

--- a/man/MakeBounds.Rd
+++ b/man/MakeBounds.Rd
@@ -14,7 +14,7 @@ MakeBounds(
 }
 \arguments{
 \item{dfResults}{\code{data.frame} A stacked summary of analysis pipeline output.
-Created by passing a list of results returned by \code{\link[gsm.core:Summarize]{Summarize()}} to
+Created by passing a list of results returned by \code{\link[gsm.core:Summarize]{gsm.core::Summarize()}} to
 \code{\link[=BindResults]{BindResults()}}. Expected columns: \code{GroupID}, \code{GroupLevel}, \code{Numerator},
 \code{Denominator}, \code{Metric}, \code{Score}, \code{Flag}, \code{MetricID}, \code{StudyID},
 \code{SnapshotDate}.}

--- a/man/gsm.reporting-package.Rd
+++ b/man/gsm.reporting-package.Rd
@@ -11,8 +11,8 @@ The Good Statistical Monitoring or 'gsm' suite of R packages provides a framewor
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://gilead-biostats.github.io/gsm.reporting/}
-  \item \url{https://github.com/Gilead-BioStats/gsm.reporting/}
+  \item \url{https://gilead-public.github.io/gsm.reporting/}
+  \item \url{https://github.com/Gilead-Public/gsm.reporting/}
 }
 
 }
@@ -21,7 +21,6 @@ Useful links:
 
 Authors:
 \itemize{
-  \item Jeremy Wildfire \email{jwildfire@gmail.com}
   \item Laura Maxwell \email{lkmaxwell23@gmail.com}
   \item Zelos Zhu \email{zelos.zhu@atorusresearch.com}
   \item Spencer Chidress \email{spencer.childress@gilead.com} (\href{https://orcid.org/0000-0001-6877-8511}{ORCID})

--- a/tests/testthat/_snaps/MakeBounds.md
+++ b/tests/testthat/_snaps/MakeBounds.md
@@ -6,50 +6,52 @@
     Message
       Creating stacked dfBounds data for strMetrics
       Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed -3,-2,2,3 to numeric vector: -3, -2, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed -3,-2,2,3 to numeric vector: -3, -2, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 139.448.
+      nStep was not provided. Setting default step to 16.116.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 0.056.
+      nStep was not provided. Setting default step to 0.064.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 0.056.
+      nStep was not provided. Setting default step to 0.064.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 288.768.
+      nStep was not provided. Setting default step to 31.744.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 18.048.
+      nStep was not provided. Setting default step to 1.984.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 72.192.
+      nStep was not provided. Setting default step to 7.936.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 288.768.
+      nStep was not provided. Setting default step to 31.744.
       Parsed -3,-2,2,3 to numeric vector: -3, -2, 2, 3
-      nStep was not provided. Setting default step to 0.068.
+      nStep was not provided. Setting default step to 0.076.
       Parsed 0.9,0.85 to numeric vector: 0.9, 0.85
       Parsed 1.5,2.5 to numeric vector: 1.5, 2.5
       Parsed 1,2 to numeric vector: 1, 2
+      Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
+      nStep was not provided. Setting default step to 0.064.
     Condition
       Warning:
       Warning: Failed to parse strThreshold ('NA') to a numeric vector.
     Output
-      # A tibble: 10,826 x 8
+      # A tibble: 11,546 x 8
          Threshold Denominator LogDenominator Numerator  Metric MetricID       StudyID
              <dbl>       <dbl>          <dbl>     <dbl>   <dbl> <chr>          <chr>  
-       1        -2        95.5           4.56     0.139 0.00146 Analysis_kri0~ AA-AA-~
-       2        -2        98.7           4.59     0.284 0.00287 Analysis_kri0~ AA-AA-~
-       3        -2       102.            4.62     0.430 0.00422 Analysis_kri0~ AA-AA-~
-       4        -2       105.            4.66     0.579 0.00550 Analysis_kri0~ AA-AA-~
-       5        -2       108.            4.69     0.729 0.00673 Analysis_kri0~ AA-AA-~
-       6        -2       112.            4.72     0.882 0.00790 Analysis_kri0~ AA-AA-~
-       7        -2       115.            4.74     1.04  0.00902 Analysis_kri0~ AA-AA-~
-       8        -2       118.            4.77     1.19  0.0101  Analysis_kri0~ AA-AA-~
-       9        -2       121.            4.80     1.35  0.0111  Analysis_kri0~ AA-AA-~
-      10        -2       125.            4.82     1.51  0.0121  Analysis_kri0~ AA-AA-~
-      # i 10,816 more rows
+       1        -2        81.5           4.40     0.106 0.00130 Analysis_kri0~ AA-AA-~
+       2        -2        84.5           4.44     0.239 0.00282 Analysis_kri0~ AA-AA-~
+       3        -2        87.4           4.47     0.373 0.00427 Analysis_kri0~ AA-AA-~
+       4        -2        90.4           4.50     0.510 0.00564 Analysis_kri0~ AA-AA-~
+       5        -2        93.3           4.54     0.648 0.00694 Analysis_kri0~ AA-AA-~
+       6        -2        96.3           4.57     0.788 0.00819 Analysis_kri0~ AA-AA-~
+       7        -2        99.2           4.60     0.931 0.00938 Analysis_kri0~ AA-AA-~
+       8        -2       102.            4.63     1.07  0.0105  Analysis_kri0~ AA-AA-~
+       9        -2       105.            4.65     1.22  0.0116  Analysis_kri0~ AA-AA-~
+      10        -2       108.            4.68     1.37  0.0127  Analysis_kri0~ AA-AA-~
+      # i 11,536 more rows
       # i 1 more variable: SnapshotDate <date>
 
 # MakeBounds uses user-supplied strMetrics (#41)
@@ -60,22 +62,22 @@
     Message
       Creating stacked dfBounds data for strMetrics
       Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
     Output
-      # A tibble: 1,224 x 8
+      # A tibble: 1,231 x 8
          Threshold Denominator LogDenominator Numerator  Metric MetricID       StudyID
              <dbl>       <dbl>          <dbl>     <dbl>   <dbl> <chr>          <chr>  
-       1        -2        95.5           4.56     0.139 0.00146 Analysis_kri0~ AA-AA-~
-       2        -2        98.7           4.59     0.284 0.00287 Analysis_kri0~ AA-AA-~
-       3        -2       102.            4.62     0.430 0.00422 Analysis_kri0~ AA-AA-~
-       4        -2       105.            4.66     0.579 0.00550 Analysis_kri0~ AA-AA-~
-       5        -2       108.            4.69     0.729 0.00673 Analysis_kri0~ AA-AA-~
-       6        -2       112.            4.72     0.882 0.00790 Analysis_kri0~ AA-AA-~
-       7        -2       115.            4.74     1.04  0.00902 Analysis_kri0~ AA-AA-~
-       8        -2       118.            4.77     1.19  0.0101  Analysis_kri0~ AA-AA-~
-       9        -2       121.            4.80     1.35  0.0111  Analysis_kri0~ AA-AA-~
-      10        -2       125.            4.82     1.51  0.0121  Analysis_kri0~ AA-AA-~
-      # i 1,214 more rows
+       1        -2        81.5           4.40     0.106 0.00130 Analysis_kri0~ AA-AA-~
+       2        -2        84.5           4.44     0.239 0.00282 Analysis_kri0~ AA-AA-~
+       3        -2        87.4           4.47     0.373 0.00427 Analysis_kri0~ AA-AA-~
+       4        -2        90.4           4.50     0.510 0.00564 Analysis_kri0~ AA-AA-~
+       5        -2        93.3           4.54     0.648 0.00694 Analysis_kri0~ AA-AA-~
+       6        -2        96.3           4.57     0.788 0.00819 Analysis_kri0~ AA-AA-~
+       7        -2        99.2           4.60     0.931 0.00938 Analysis_kri0~ AA-AA-~
+       8        -2       102.            4.63     1.07  0.0105  Analysis_kri0~ AA-AA-~
+       9        -2       105.            4.65     1.22  0.0116  Analysis_kri0~ AA-AA-~
+      10        -2       108.            4.68     1.37  0.0127  Analysis_kri0~ AA-AA-~
+      # i 1,221 more rows
       # i 1 more variable: SnapshotDate <date>
 
 # MakeBounds makes poisson dfBounds (#41)
@@ -86,49 +88,51 @@
     Message
       Creating stacked dfBounds data for strMetrics
       Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed -3,-2,2,3 to numeric vector: -3, -2, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed -3,-2,2,3 to numeric vector: -3, -2, 2, 3
-      nStep was not provided. Setting default step to 3.224.
+      nStep was not provided. Setting default step to 2.944.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 139.448.
+      nStep was not provided. Setting default step to 16.116.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 0.056.
+      nStep was not provided. Setting default step to 0.064.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 0.056.
+      nStep was not provided. Setting default step to 0.064.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 288.768.
+      nStep was not provided. Setting default step to 31.744.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 18.048.
+      nStep was not provided. Setting default step to 1.984.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 72.192.
+      nStep was not provided. Setting default step to 7.936.
       Parsed 2,3 to numeric vector: 2, 3
-      nStep was not provided. Setting default step to 288.768.
+      nStep was not provided. Setting default step to 31.744.
       Parsed -3,-2,2,3 to numeric vector: -3, -2, 2, 3
-      nStep was not provided. Setting default step to 0.068.
+      nStep was not provided. Setting default step to 0.076.
       Parsed 0.9,0.85 to numeric vector: 0.9, 0.85
       Parsed 1.5,2.5 to numeric vector: 1.5, 2.5
       Parsed 1,2 to numeric vector: 1, 2
+      Parsed -2,-1,2,3 to numeric vector: -2, -1, 2, 3
+      nStep was not provided. Setting default step to 0.064.
     Condition
       Warning:
       Warning: Failed to parse strThreshold ('NA') to a numeric vector.
     Output
-      # A tibble: 10,826 x 8
+      # A tibble: 11,546 x 8
          Threshold Denominator LogDenominator Numerator  Metric MetricID       StudyID
              <dbl>       <dbl>          <dbl>     <dbl>   <dbl> <chr>          <chr>  
-       1        -2        95.5           4.56     0.139 0.00146 Analysis_kri0~ AA-AA-~
-       2        -2        98.7           4.59     0.284 0.00287 Analysis_kri0~ AA-AA-~
-       3        -2       102.            4.62     0.430 0.00422 Analysis_kri0~ AA-AA-~
-       4        -2       105.            4.66     0.579 0.00550 Analysis_kri0~ AA-AA-~
-       5        -2       108.            4.69     0.729 0.00673 Analysis_kri0~ AA-AA-~
-       6        -2       112.            4.72     0.882 0.00790 Analysis_kri0~ AA-AA-~
-       7        -2       115.            4.74     1.04  0.00902 Analysis_kri0~ AA-AA-~
-       8        -2       118.            4.77     1.19  0.0101  Analysis_kri0~ AA-AA-~
-       9        -2       121.            4.80     1.35  0.0111  Analysis_kri0~ AA-AA-~
-      10        -2       125.            4.82     1.51  0.0121  Analysis_kri0~ AA-AA-~
-      # i 10,816 more rows
+       1        -2        81.5           4.40     0.106 0.00130 Analysis_kri0~ AA-AA-~
+       2        -2        84.5           4.44     0.239 0.00282 Analysis_kri0~ AA-AA-~
+       3        -2        87.4           4.47     0.373 0.00427 Analysis_kri0~ AA-AA-~
+       4        -2        90.4           4.50     0.510 0.00564 Analysis_kri0~ AA-AA-~
+       5        -2        93.3           4.54     0.648 0.00694 Analysis_kri0~ AA-AA-~
+       6        -2        96.3           4.57     0.788 0.00819 Analysis_kri0~ AA-AA-~
+       7        -2        99.2           4.60     0.931 0.00938 Analysis_kri0~ AA-AA-~
+       8        -2       102.            4.63     1.07  0.0105  Analysis_kri0~ AA-AA-~
+       9        -2       105.            4.65     1.22  0.0116  Analysis_kri0~ AA-AA-~
+      10        -2       108.            4.68     1.37  0.0127  Analysis_kri0~ AA-AA-~
+      # i 11,536 more rows
       # i 1 more variable: SnapshotDate <date>
 

--- a/vignettes/DataReporting.Rmd
+++ b/vignettes/DataReporting.Rmd
@@ -43,7 +43,7 @@ These functions and workflows produce data frames, visualizations, metadata, and
 
 ![](data_model_detailed.png){width="100%"}
 
-All of the functions to create the data frames in the reporting data model will run automatically and sequentially when a user specifies the metadata and data needed for the report, and calls `workr::RunWorkflow()` on the YAML files in the `workflow/3_reporting` directory. To create a report, the output of the reporting YAMLs is fed into the YAMLs in the `workflow/4_modules` directory to produce an HTML document with all charts and tables created in the reporting workflow. For a more detailed discussion of the YAML file and directory structure, see the [`{gsm.core}` Extensions vignette](https://gilead-biostats.github.io/gsm.core/articles/gsmExtensions.html).
+All of the functions to create the data frames in the reporting data model will run automatically and sequentially when a user specifies the metadata and data needed for the report, and calls `workr::RunWorkflow()` on the YAML files in the `workflow/3_reporting` directory. To create a report, the output of the reporting YAMLs is fed into the YAMLs in the `workflow/4_modules` directory to produce an HTML document with all charts and tables created in the reporting workflow. For a more detailed discussion of the YAML file and directory structure, see the [`{gsm.core}` Extensions vignette](https://gilead-public.github.io/gsm.core/articles/gsmExtensions.html).
 
 Each of the individual functions can also be run independently outside of a specified yaml workflow.
 
@@ -53,7 +53,7 @@ For the purposes of this documentation, we will evaluate the input(s) and output
   
 ## Case Study - Step-by-Step Full Site-Level Report
   
-We will use sample clinical data simulated from the [`{gsm.datasim}`](https://github.com/Gilead-BioStats/gsm.datasim) package to run the full site-level report for all 12 KRIs included in this package. The focus of this vignette is the reporting workflow, so the output of the analytics workflow will be briefly discussed, but only in the context of *inputs*  to the reporting workflow.
+We will use sample clinical data simulated from the [`{gsm.datasim}`](https://github.com/Gilead-Public/gsm.datasim) package to run the full site-level report for all 12 KRIs included in this package. The focus of this vignette is the reporting workflow, so the output of the analytics workflow will be briefly discussed, but only in the context of *inputs*  to the reporting workflow.
 
 Additional supporting functions are explored in [Appendix 1](#appendix-1).
 


### PR DESCRIPTION
## Summary
Updates all direct `Gilead-BioStats` org links to `Gilead-Public` across docs, config, and metadata files.

## Changes
- Replaced `github.com/Gilead-BioStats` → `github.com/Gilead-Public` in all applicable files.
- Replaced `gilead-biostats.github.io` → `gilead-public.github.io` in all applicable files.

## Intentional non-updated links
- `NEWS.md` issue/PR links (lines 9, 27, 59, 63, 67) — historical changelog entries.
- `orgs/Gilead-BioStats/projects/41` in `.github/CONTRIBUTING.md` and issue templates — org-level project board.

## Validation
- `grep -rn "Gilead-BioStats\|gilead-biostats.github.io" --exclude-dir=man --exclude-dir=docs .` returns only the intentional keeps listed above.

Closes #72